### PR TITLE
Add a find function

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ let filters = { statusCode: 'Operational', countryCode: 'US' }
 let filters = {}
 ```
 
+## `.find(filters)` : Record | undefined
+
+Returns the value of the first record in the array that satisfies the provided filters. Otherwise ``undefined`` is returned.
+Filters are identical to the filters described in ``.filter(filters)``
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ let filters = {}
 ## `.find(filters)` : Record | undefined
 
 Returns the value of the first record in the array that satisfies the provided filters. Otherwise ``undefined`` is returned.
-Filters are identical to the filters described in ``.filter(filters)``
+Filters are identical to the filters described in ``.filter(filters)``.
 
 
 ## Example

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function filter ( filters ) {
       throw new TypeError('Invalid mnc parameter (string expected)');
     }
   }
-  
+
   if (filters.countryCode != undefined) {
     if (typeof filters.countryCode === 'string') {
       countryCode = filters.countryCode;
@@ -85,8 +85,13 @@ function filter ( filters ) {
   if (mnc) {
     result = result.filter( record => record['mnc'] === mnc );
   }
-  
+
   return result;
+}
+
+function find (filters) {
+  // return the first element of undefined, as filter will always return an array
+  return filter(filters)[0]
 }
 
 module.exports = { all, statusCodes, filter };


### PR DESCRIPTION
Many times when filtering all a single result is needed, specifically if both mcc and mnc was passed. Adding a find function will make it easier to handle single results.