### PR TITLE
fix: TeliaSonera Finland Oyj -> Telia Finland Oyj

### DIFF
--- a/mcc-mnc-list.json
+++ b/mcc-mnc-list.json
@@ -2322,7 +2322,7 @@
     "mcc": "244",
     "mnc": "92",
     "brand": "Sonera",
-    "operator": "TeliaSonera Finland Oyj",
+    "operator": "Telia Finland Oyj",
     "status": "Not operational",
     "bands": "Unknown",
     "notes": "MNC withdrawn"


### PR DESCRIPTION
This company was also renamed: https://www.telia.fi/telia-yrityksena