### PR TITLE
Add CSV support

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
+const csvstringify = require('csv-stringify/lib/sync')
 
 const WIKI_URL = 'https://en.wikipedia.org/wiki/Mobile_country_code';
 const WIKI_URL_REGIONS = [
@@ -15,7 +16,8 @@ const WIKI_URL_REGIONS = [
   'https://en.wikipedia.org/wiki/Mobile_Network_Codes_in_ITU_region_7xx_(South_America)'
 ];
 
-const MCC_MNC_OUTPUT_FILE = path.join( __dirname, 'mcc-mnc-list.json');
+const MCC_MNC_OUTPUT_FILE_JSON = path.join( __dirname, 'mcc-mnc-list.json');
+const MCC_MNC_OUTPUT_FILE_CSV = path.join( __dirname, 'mcc-mnc-list.csv');
 const STATUS_CODES_OUTPUT_FILE = path.join( __dirname, 'status-codes.json');
 
 
@@ -166,11 +168,19 @@ function collect (resolve, from, records, statusCodes, globals) {
 }
 
 function writeData(records, statusCodes) {
-  fs.writeFile( MCC_MNC_OUTPUT_FILE, JSON.stringify( records, null, 2 ), err => {
+  fs.writeFile( MCC_MNC_OUTPUT_FILE_JSON, JSON.stringify( records, null, 2 ), err => {
     if ( err ) {
       throw err;
     }
-    console.log( 'MCC-MNC list saved to ' + MCC_MNC_OUTPUT_FILE );
+    console.log( 'MCC-MNC list saved to ' + MCC_MNC_OUTPUT_FILE_JSON );
+    console.log( 'Total ' + records.length + ' records' );
+  });
+
+  fs.writeFile( MCC_MNC_OUTPUT_FILE_CSV, csvstringify( records , {header: true} ), err => {
+    if ( err ) {
+      throw err;
+    }
+    console.log( 'MCC-MNC list saved to ' + MCC_MNC_OUTPUT_FILE_CSV );
     console.log( 'Total ' + records.length + ' records' );
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mcc-mnc-list",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -836,6 +836,12 @@
           "dev": true
         }
       }
+    },
+    "csv-stringify": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.5.1.tgz",
+      "integrity": "sha512-HM0/86Ks8OwFbaYLd495tqTs1NhscZL52dC4ieKYumy8+nawQYC0xZ63w1NqLf0M148T2YLYqowoImc1giPn0g==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "devDependencies": {
     "ava": "^3.10.1",
+    "csv-stringify": "^5.5.1",
     "eslint": "^7.5.0",
     "jsdom": "^16.3.0"
   },


### PR DESCRIPTION
Running `fetch.js` now also generates `mcc-mnc-list.csv` file.

```sh
$ ls -lh mcc-mnc-list.*
-rw-r--r--  1 user  staff   283K Apr  8 13:36 mcc-mnc-list.csv
-rw-r--r--  1 user  staff   763K Apr  8 13:23 mcc-mnc-list.json
```

Closes: #15